### PR TITLE
[#67] Feat : 내 지원서 모아보기 UI 생성 및 DB 연동

### DIFF
--- a/app/src/main/java/com/example/chaining/data/local/Converters.kt
+++ b/app/src/main/java/com/example/chaining/data/local/Converters.kt
@@ -16,14 +16,14 @@ class Converters {
         if (value.isEmpty()) emptyList() else Json.decodeFromString(value)
 
     @TypeConverter
-    fun fromApplicationList(list: List<Application>): String = Json.encodeToString(list)
+    fun fromApplicationMap(map: Map<String, Application>): String = Json.encodeToString(map)
 
     @TypeConverter
     fun fromPostMap(map: Map<String, RecruitPost>): String = Json.encodeToString(map)
 
     @TypeConverter
-    fun toApplicationList(value: String): List<Application> =
-        if (value.isEmpty()) emptyList() else Json.decodeFromString(value)
+    fun toApplicationMap(value: String): Map<String, Application> =
+        if (value.isEmpty()) emptyMap() else Json.decodeFromString(value)
 
     @TypeConverter
     fun toPostMap(value: String): Map<String, RecruitPost> =

--- a/app/src/main/java/com/example/chaining/data/local/entity/UserEntity.kt
+++ b/app/src/main/java/com/example/chaining/data/local/entity/UserEntity.kt
@@ -17,7 +17,7 @@ data class UserEntity(
     val preferredLanguages: List<LanguagePref> = emptyList(), // 선호 언어 + 수준
     val isPublic: Boolean = true,                 // 모집/지원 현황 공개 여부
     val recruitPosts: Map<String, RecruitPost> = emptyMap(), // 내가 모집한 글 (Post ID만 저장)
-    val applications: List<Application> = emptyList(), // 내가 지원한 글 (Application ID만 저장)
+    val applications: Map<String, Application> = emptyMap(), // 내가 지원한 글 (Application ID만 저장)
     val createdAt: Long = 0L,                     // 서버 타임스탬프
     val isDeleted: Boolean = false,                // Soft Delete 플래그 추가
     val likedPosts: Map<String, Boolean> = emptyMap()     // 관심글 postId

--- a/app/src/main/java/com/example/chaining/data/repository/ApplicationRepository.kt
+++ b/app/src/main/java/com/example/chaining/data/repository/ApplicationRepository.kt
@@ -47,7 +47,7 @@ class ApplicationRepository @Inject constructor(
             "/posts/${application.postId}/applications/$applicationId" to newApplication,
 
             // 3. users/{uid}/myApplications/{applicationId} = true
-            "/users/$uid/myApplications/$applicationId" to newApplication
+            "/users/$uid/applications/$applicationId" to newApplication
         )
 
         // 원자적 업데이트 수행

--- a/app/src/main/java/com/example/chaining/data/repository/UserRepository.kt
+++ b/app/src/main/java/com/example/chaining/data/repository/UserRepository.kt
@@ -191,7 +191,7 @@ class UserRepository @Inject constructor(
             preferredLanguages = updates["preferredLanguages"] as? List<LanguagePref>
                 ?: preferredLanguages,
             recruitPosts = updates["recruitPosts"] as? Map<String, RecruitPost> ?: recruitPosts,
-            applications = updates["applications"] as? List<Application> ?: applications
+            applications = updates["applications"] as? Map<String, Application> ?: applications
         )
     }
 }

--- a/app/src/main/java/com/example/chaining/domain/model/User.kt
+++ b/app/src/main/java/com/example/chaining/domain/model/User.kt
@@ -14,7 +14,7 @@ data class User(
     @get:PropertyName("isPublic")
     val isPublic: Boolean = true,                 // 모집/지원 현황 공개 여부
     val recruitPosts: Map<String, RecruitPost> = emptyMap(), // 내가 모집한 글
-    val applications: List<Application> = emptyList(), // 내가 지원한 글
+    val applications: Map<String, Application> = emptyMap(), // 내가 지원한 글
     val createdAt: Long = 0L,                     // 서버 타임스탬프
     @get:PropertyName("isDeleted")
     val isDeleted: Boolean = false,                // Soft Delete 플래그 추가

--- a/app/src/main/java/com/example/chaining/ui/component/CardItem.kt
+++ b/app/src/main/java/com/example/chaining/ui/component/CardItem.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
 import com.example.chaining.R
+import com.example.chaining.domain.model.Application
 import com.example.chaining.domain.model.RecruitPost
 import com.example.chaining.domain.model.UserSummary
 
@@ -36,14 +37,14 @@ fun CardItem(
     onClick: () -> Unit,
     type: String, // "모집글" or "지원서"
     recruitPost: RecruitPost? = null,
-    application: String? = null,
+    application: Application? = null,
     remainingTime: String? = null,
     onLeftButtonClick: () -> Unit = {},
     onRightButtonClick: () -> Unit = {}
 ) {
     val title = when (type) {
         "모집글" -> recruitPost?.title ?: "제목 없음"
-        "지원서" -> application ?: "지원서 제목 없음"
+        "지원서" -> application?.recruitPostTitle ?: "지원서 제목 없음"
         else -> "제목 없음"
     }
 

--- a/app/src/main/java/com/example/chaining/ui/navigation/NavGraph.kt
+++ b/app/src/main/java/com/example/chaining/ui/navigation/NavGraph.kt
@@ -22,6 +22,7 @@ import com.example.chaining.ui.screen.HomeScreen
 import com.example.chaining.ui.screen.JoinPostScreen
 import com.example.chaining.ui.screen.KRQuizScreen
 import com.example.chaining.ui.screen.MainHomeScreen
+import com.example.chaining.ui.screen.MyApplicationsScreen
 import com.example.chaining.ui.screen.MyApplyScreen
 import com.example.chaining.ui.screen.MyPageScreen
 import com.example.chaining.ui.screen.MyPostsScreen
@@ -55,7 +56,7 @@ fun NavGraph(navController: NavHostController, modifier: Modifier = Modifier) {
                 }
             )
         }
-        composable(Screen.AdminLogin.route){
+        composable(Screen.AdminLogin.route) {
             AdminLoginScreen(
                 onBackClick = { navController.popBackStack() }
             )
@@ -76,7 +77,8 @@ fun NavGraph(navController: NavHostController, modifier: Modifier = Modifier) {
             MyPageScreen(
                 onKRQuizClick = { navController.navigate("krQuiz") },
                 onENQuizClick = { navController.navigate("enQuiz") },
-                onMyPostsClick = { navController.navigate(route = Screen.MyPosts.route) }
+                onMyPostsClick = { navController.navigate(route = Screen.MyPosts.route) },
+                onMyApplicationsClick = { navController.navigate(route = Screen.MyApplications.route) }
             )
         }
         composable(Screen.MainHome.route) {
@@ -189,6 +191,9 @@ fun NavGraph(navController: NavHostController, modifier: Modifier = Modifier) {
 
         composable(route = Screen.MyPosts.route) {
             MyPostsScreen()
+        }
+        composable(route = Screen.MyApplications.route) {
+            MyApplicationsScreen()
         }
     }
 }

--- a/app/src/main/java/com/example/chaining/ui/navigation/Screen.kt
+++ b/app/src/main/java/com/example/chaining/ui/navigation/Screen.kt
@@ -26,6 +26,7 @@ sealed class Screen(val route: String) {
     }
 
     object MyPosts : Screen("myPosts")
+    object MyApplications : Screen("myApplications")
 
     object KRQuiz : Screen("krQuiz")
     object ENQuiz : Screen("enQuiz")

--- a/app/src/main/java/com/example/chaining/ui/screen/MyApplicationsScreen.kt
+++ b/app/src/main/java/com/example/chaining/ui/screen/MyApplicationsScreen.kt
@@ -1,0 +1,134 @@
+package com.example.chaining.ui.screen
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.example.chaining.R
+import com.example.chaining.ui.component.CardItem
+import com.example.chaining.viewmodel.UserViewModel
+
+@Composable
+fun MyApplicationsScreen(
+    onBackClick: () -> Unit = {},
+    userViewModel: UserViewModel = hiltViewModel(),
+) {
+    val userState by userViewModel.user.collectAsState()
+
+    val myApplications = userState?.applications.orEmpty()
+
+    var showOnlyFinishedApplications by remember { mutableStateOf(false) }
+
+    val filteredApplications = if (showOnlyFinishedApplications) {
+        myApplications.filter { application -> application.value.status != "PENDING" }
+    } else {
+        myApplications
+    }
+
+    Scaffold(
+        topBar = {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(64.dp)
+                    .clip(RoundedCornerShape(bottomEnd = 20.dp))
+                    .background(Color(0xFF4A526A)),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                IconButton(onClick = onBackClick) {
+                    Icon(
+                        painter = painterResource(id = R.drawable.back_arrow),
+                        contentDescription = "뒤로 가기",
+                        modifier = Modifier.size(20.dp),
+                        tint = Color.White
+                    )
+                }
+
+                // 제목
+                Text(
+                    text = "내 모집글 보기",
+                    modifier = Modifier.weight(1f),
+                    color = Color.White,
+                    fontSize = 20.sp,
+                    textAlign = TextAlign.Center
+                )
+                Spacer(modifier = Modifier.width(48.dp))
+            }
+        },
+        containerColor = Color(0xFFF3F6FF)
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+                .padding(16.dp)
+                .verticalScroll(rememberScrollState())
+        ) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 8.dp),
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                // 새로 만든 CommunityActionButton 호출
+                ActionButton(
+                    modifier = Modifier.weight(1f),
+                    iconRes = R.drawable.post,
+                    text = if (showOnlyFinishedApplications) "전체 지원서 보기" else "지원서 결과 보기",
+                    onClick = {
+                        showOnlyFinishedApplications = !showOnlyFinishedApplications
+                    }
+                )
+            }
+            if (filteredApplications.isEmpty()) {
+                // 데이터가 없을 때
+                Text(
+                    text = "등록된 지원서가 없습니다.",
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(top = 50.dp),
+                    color = Color.Gray,
+                    textAlign = TextAlign.Center
+                )
+            } else {
+                // 모집글 목록 표시
+                filteredApplications.forEach { application ->
+                    CardItem(
+                        onClick = { },
+                        type = "지원서",
+                        application = application.value,
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/chaining/ui/screen/MyPageScreen.kt
+++ b/app/src/main/java/com/example/chaining/ui/screen/MyPageScreen.kt
@@ -62,6 +62,7 @@ fun MyPageScreen(
     onKRQuizClick: () -> Unit,
     onENQuizClick: () -> Unit,
     onMyPostsClick: () -> Unit,
+    onMyApplicationsClick: () -> Unit,
 ) {
     val userState by userViewModel.user.collectAsState()
 
@@ -149,7 +150,7 @@ fun MyPageScreen(
             onClick = { type ->
                 when (type) {
                     "모집 현황" -> onMyPostsClick()
-                    "지원 현황" -> {}
+                    "지원 현황" -> onMyApplicationsClick()
                 }
             }
         )


### PR DESCRIPTION
## 구현 내용
- 내 지원서 모아보기 UI 생성
- DB 연동
- User의 필드 데이터 타입 변경에 따른 파일들 수정
- 화면 간 연결
- Props Drilling 방지
- 지원서 Repository 멀티패스 경로 오류 수정(myApplications -> applications)

## 추후 수정 내용
- UI 수정
- 필터링 버튼 UI 수정 및 기능 테스트 필요
- 데이터 로딩, 화면 이동 시 로딩 인디케이터 필요

## 참고 이슈
- closes #67 